### PR TITLE
Add message processor

### DIFF
--- a/gcp/message.go
+++ b/gcp/message.go
@@ -1,20 +1,20 @@
 package gcp
 
 import (
-	"cloud.google.com/go/pubsub"
+	gps "cloud.google.com/go/pubsub"
 
-	basepubsub "github.com/milosgajdos/pubsub"
+	"github.com/milosgajdos/pubsub"
 )
 
 // Message implements the pubsub.MessageAcker interface for GCP Cloud Pub/Sub
 type Message struct {
-	msg      *pubsub.Message
+	msg      *gps.Message
 	metadata map[string]any
 }
 
 // NewMessage creates a new message from a Google Cloud Pub/Sub message
-func NewMessage(msg *pubsub.Message, options ...basepubsub.MessageOption) *Message {
-	opts := &basepubsub.MessageOptions{}
+func NewMessage(msg *gps.Message, options ...pubsub.MessageOption) *Message {
+	opts := &pubsub.MessageOptions{}
 	for _, option := range options {
 		option(opts)
 	}

--- a/gcp/message_test.go
+++ b/gcp/message_test.go
@@ -4,13 +4,13 @@ import (
 	"reflect"
 	"testing"
 
-	"cloud.google.com/go/pubsub"
+	gps "cloud.google.com/go/pubsub"
 
-	basepubsub "github.com/milosgajdos/pubsub"
+	"github.com/milosgajdos/pubsub"
 )
 
-func TestNewMessage(t *testing.T) {
-	mockPubsubMsg := &pubsub.Message{
+func TestNeMessage(t *testing.T) {
+	mockPubsubMsg := &gps.Message{
 		ID:         "test-id",
 		Data:       []byte("test-data"),
 		Attributes: map[string]string{"key": "value"},
@@ -18,9 +18,9 @@ func TestNewMessage(t *testing.T) {
 
 	metadata := map[string]any{"meta-key": "meta-value"}
 
-	msg := NewMessage(mockPubsubMsg, basepubsub.WithMetadata(metadata))
+	msg := NewMessage(mockPubsubMsg, pubsub.WithMetadata(metadata))
 	if msg == nil {
-		t.Fatal("NewMessage returned nil")
+		t.Fatal("NeMessage returned nil")
 	}
 
 	if !reflect.DeepEqual(msg.msg, mockPubsubMsg) {
@@ -28,28 +28,28 @@ func TestNewMessage(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(msg.metadata, metadata) {
-		t.Errorf("Message metadata does not match expected: got %v, want %v", msg.metadata, metadata)
+		t.Errorf("Message metadata does not match expected: got %v, ant %v", msg.metadata, metadata)
 	}
 }
 
 func TestMessage(t *testing.T) {
 	t.Run("ID", func(t *testing.T) {
 		expectedID := "test-message-id"
-		mockPubsubMsg := &pubsub.Message{ID: expectedID}
+		mockPubsubMsg := &gps.Message{ID: expectedID}
 		msg := &Message{msg: mockPubsubMsg}
 
 		if id := msg.ID(); id != expectedID {
-			t.Errorf("ID() = %v, want %v", id, expectedID)
+			t.Errorf("ID() = %v, ant %v", id, expectedID)
 		}
 	})
 
 	t.Run("Data", func(t *testing.T) {
 		expectedData := []byte("test message data")
-		mockPubsubMsg := &pubsub.Message{Data: expectedData}
+		mockPubsubMsg := &gps.Message{Data: expectedData}
 		msg := &Message{msg: mockPubsubMsg}
 
 		if data := msg.Data(); !reflect.DeepEqual(data, expectedData) {
-			t.Errorf("Data() = %v, want %v", data, expectedData)
+			t.Errorf("Data() = %v, ant %v", data, expectedData)
 		}
 	})
 
@@ -58,11 +58,11 @@ func TestMessage(t *testing.T) {
 			"attr1": "value1",
 			"attr2": "value2",
 		}
-		mockPubsubMsg := &pubsub.Message{Attributes: expectedAttrs}
+		mockPubsubMsg := &gps.Message{Attributes: expectedAttrs}
 		msg := &Message{msg: mockPubsubMsg}
 
 		if attrs := msg.Attributes(); !reflect.DeepEqual(attrs, expectedAttrs) {
-			t.Errorf("Attributes() = %v, want %v", attrs, expectedAttrs)
+			t.Errorf("Attributes() = %v, ant %v", attrs, expectedAttrs)
 		}
 	})
 
@@ -72,21 +72,21 @@ func TestMessage(t *testing.T) {
 			msg := &Message{metadata: existingMetadata}
 
 			if metadata := msg.Metadata(); !reflect.DeepEqual(metadata, existingMetadata) {
-				t.Errorf("Metadata() = %v, want %v", metadata, existingMetadata)
+				t.Errorf("Metadata() = %v, ant %v", metadata, existingMetadata)
 			}
 		})
 
 		t.Run("NilMetadata", func(t *testing.T) {
-			// Test with nil metadata (should initialize a new map)
+			// Test ith nil metadata (should initialize a new map)
 			msg := &Message{metadata: nil}
 			metadata := msg.Metadata()
 
 			if metadata == nil {
-				t.Error("Metadata() should initialize a new map when metadata is nil")
+				t.Error("Metadata() should initialize a ne map when metadata is nil")
 			}
 
 			if len(metadata) != 0 {
-				t.Errorf("Newly initialized metadata should be empty, got %v", metadata)
+				t.Errorf("Nely initialized metadata should be empty, got %v", metadata)
 			}
 		})
 	})

--- a/gcp/message_test.go
+++ b/gcp/message_test.go
@@ -86,7 +86,7 @@ func TestMessage(t *testing.T) {
 			}
 
 			if len(metadata) != 0 {
-				t.Errorf("Nely initialized metadata should be empty, got %v", metadata)
+				t.Errorf("Newly initialized metadata should be empty, got %v", metadata)
 			}
 		})
 	})

--- a/gcp/message_test.go
+++ b/gcp/message_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/milosgajdos/pubsub"
 )
 
-func TestNeMessage(t *testing.T) {
+func TestNewMessage(t *testing.T) {
 	mockPubsubMsg := &gps.Message{
 		ID:         "test-id",
 		Data:       []byte("test-data"),

--- a/gcp/message_test.go
+++ b/gcp/message_test.go
@@ -28,7 +28,7 @@ func TestNeMessage(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(msg.metadata, metadata) {
-		t.Errorf("Message metadata does not match expected: got %v, ant %v", msg.metadata, metadata)
+		t.Errorf("Message metadata does not match expected: got %v, want %v", msg.metadata, metadata)
 	}
 }
 

--- a/gcp/message_test.go
+++ b/gcp/message_test.go
@@ -82,7 +82,7 @@ func TestMessage(t *testing.T) {
 			metadata := msg.Metadata()
 
 			if metadata == nil {
-				t.Error("Metadata() should initialize a ne map when metadata is nil")
+				t.Error("Metadata() should initialize a new map when metadata is nil")
 			}
 
 			if len(metadata) != 0 {

--- a/gcp/message_test.go
+++ b/gcp/message_test.go
@@ -39,7 +39,7 @@ func TestMessage(t *testing.T) {
 		msg := &Message{msg: mockPubsubMsg}
 
 		if id := msg.ID(); id != expectedID {
-			t.Errorf("ID() = %v, ant %v", id, expectedID)
+			t.Errorf("ID() = %v, want %v", id, expectedID)
 		}
 	})
 
@@ -77,7 +77,6 @@ func TestMessage(t *testing.T) {
 		})
 
 		t.Run("NilMetadata", func(t *testing.T) {
-			// Test ith nil metadata (should initialize a new map)
 			msg := &Message{metadata: nil}
 			metadata := msg.Metadata()
 

--- a/gcp/publisher_test.go
+++ b/gcp/publisher_test.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"testing"
 
-	basepubsub "github.com/milosgajdos/pubsub"
+	"github.com/milosgajdos/pubsub"
 )
 
 func TestNewPublisher(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("invalid project ID", func(t *testing.T) {
-		_, err := NewPublisher(ctx, "", basepubsub.WithTopic("test-topic"))
+		_, err := NewPublisher(ctx, "", pubsub.WithTopic("test-topic"))
 		if err != ErrInvalidProject {
 			t.Errorf("expected ErrInvalidProject, got %v", err)
 		}

--- a/gcp/subscriber_integration_test.go
+++ b/gcp/subscriber_integration_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/pubsub"
-	"github.com/milosgajdos/pubsub/gcp"
+	gps "cloud.google.com/go/pubsub"
 
-	basepubsub "github.com/milosgajdos/pubsub"
+	"github.com/milosgajdos/pubsub"
+	"github.com/milosgajdos/pubsub/gcp"
 )
 
 func TestSubscriberIntegration(t *testing.T) {
@@ -27,8 +27,8 @@ func TestSubscriberIntegration(t *testing.T) {
 		subscriber, err := gcp.NewSubscriber(
 			ctx,
 			gcp.TestProjectID,
-			basepubsub.WithSub(gcp.TestSubscriptionID),
-			basepubsub.WithConcurrency(2),
+			pubsub.WithSub(gcp.TestSubscriptionID),
+			pubsub.WithConcurrency(2),
 		)
 		if err != nil {
 			t.Fatalf("Failed to create subscriber: %v", err)
@@ -37,7 +37,7 @@ func TestSubscriberIntegration(t *testing.T) {
 
 		// Setup message reception
 		var wg sync.WaitGroup
-		receivedMessages := make([]basepubsub.MessageAcker, 0)
+		receivedMessages := make([]pubsub.MessageAcker, 0)
 		messagesMutex := &sync.Mutex{}
 
 		// Start receiving messages
@@ -48,7 +48,7 @@ func TestSubscriberIntegration(t *testing.T) {
 			subCtx, subCancel := context.WithTimeout(ctx, 10*time.Second)
 			defer subCancel()
 
-			err := subscriber.Subscribe(subCtx, func(_ context.Context, msg basepubsub.MessageAcker) error {
+			err := subscriber.Subscribe(subCtx, func(_ context.Context, msg pubsub.MessageAcker) error {
 				messagesMutex.Lock()
 				receivedMessages = append(receivedMessages, msg)
 				messagesMutex.Unlock()
@@ -70,7 +70,7 @@ func TestSubscriberIntegration(t *testing.T) {
 			messageData := fmt.Appendf(nil, "test-message-%d", i)
 			messageAttrs := map[string]string{"sequence": fmt.Sprintf("%d", i)}
 
-			result := topic.Publish(ctx, &pubsub.Message{
+			result := topic.Publish(ctx, &gps.Message{
 				Data:       messageData,
 				Attributes: messageAttrs,
 			})
@@ -131,8 +131,8 @@ func TestSubscriberIntegration(t *testing.T) {
 		subscriber, err := gcp.NewSubscriber(
 			ctx,
 			gcp.TestProjectID,
-			basepubsub.WithSub(gcp.TestSubscriptionID),
-			basepubsub.WithConcurrency(5),
+			pubsub.WithSub(gcp.TestSubscriptionID),
+			pubsub.WithConcurrency(5),
 		)
 		if err != nil {
 			t.Fatalf("Failed to create concurrent subscriber: %v", err)
@@ -153,7 +153,7 @@ func TestSubscriberIntegration(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			err := subscriber.Subscribe(subCtx, func(_ context.Context, msg basepubsub.MessageAcker) error {
+			err := subscriber.Subscribe(subCtx, func(_ context.Context, msg pubsub.MessageAcker) error {
 				t.Logf("Concurrent processing message: %s", string(msg.Data()))
 				// Simulate processing time to test concurrency
 				time.Sleep(200 * time.Millisecond)
@@ -173,7 +173,7 @@ func TestSubscriberIntegration(t *testing.T) {
 		batchSize := 10
 		for i := range batchSize {
 			messageData := fmt.Appendf(nil, "concurrent-msg-%d", i)
-			result := topic.Publish(ctx, &pubsub.Message{
+			result := topic.Publish(ctx, &gps.Message{
 				Data: messageData,
 				Attributes: map[string]string{
 					"test": "concurrent",

--- a/gcp/subscriber_test.go
+++ b/gcp/subscriber_test.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"testing"
 
-	basepubsub "github.com/milosgajdos/pubsub"
+	"github.com/milosgajdos/pubsub"
 )
 
 func TestNewSubscriber(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("invalid project ID", func(t *testing.T) {
-		_, err := NewSubscriber(ctx, "", basepubsub.WithSub("test-subscription"))
+		_, err := NewSubscriber(ctx, "", pubsub.WithSub("test-subscription"))
 		if err != ErrInvalidProject {
 			t.Errorf("expected %v, got %v", ErrInvalidProject, err)
 		}
@@ -32,7 +32,7 @@ func TestSubscriberAlreadySubscribed(t *testing.T) {
 	}
 
 	// Create a mock MessageHandler
-	handler := func(_ context.Context, _ basepubsub.MessageAcker) error {
+	handler := func(_ context.Context, _ pubsub.MessageAcker) error {
 		return nil
 	}
 

--- a/options.go
+++ b/options.go
@@ -97,3 +97,28 @@ func WithMetadata(metadata map[string]any) MessageOption {
 		o.Metadata = metadata
 	}
 }
+
+// ProcessorOptions is used for configuring processors
+type ProcessorOptions struct {
+	// Unmarshaler is used for unmarshaling messages
+	Unmarshaler MessageUnmarshaler
+	// Extractor is used for extracting message type
+	Extractor MessageTypeExtractor
+}
+
+// ProcessorOption is used for configuring processors
+type ProcessorOption func(*ProcessorOptions)
+
+// WithUnmarshaler sets the unmarshaler for the processor
+func WithUnmarshaler(unmarshaler MessageUnmarshaler) ProcessorOption {
+	return func(p *ProcessorOptions) {
+		p.Unmarshaler = unmarshaler
+	}
+}
+
+// WithExtractor sets the extractor for the processor
+func WithExtractor(extractor MessageTypeExtractor) ProcessorOption {
+	return func(p *ProcessorOptions) {
+		p.Extractor = extractor
+	}
+}

--- a/processor/errors.go
+++ b/processor/errors.go
@@ -1,0 +1,9 @@
+package processor
+
+import "errors"
+
+var (
+	ErrInvalidMesageType  = errors.New("invalid message type")
+	ErrUnknownMessageType = errors.New("unknown message type")
+	ErrInvalidHandler     = errors.New("invalid handler")
+)

--- a/processor/errors.go
+++ b/processor/errors.go
@@ -3,7 +3,7 @@ package processor
 import "errors"
 
 var (
-	ErrInvalidMessageType  = errors.New("invalid message type")
+	ErrInvalidMessageType = errors.New("invalid message type")
 	ErrUnknownMessageType = errors.New("unknown message type")
 	ErrInvalidHandler     = errors.New("invalid handler")
 )

--- a/processor/errors.go
+++ b/processor/errors.go
@@ -3,7 +3,7 @@ package processor
 import "errors"
 
 var (
-	ErrInvalidMesageType  = errors.New("invalid message type")
+	ErrInvalidMessageType  = errors.New("invalid message type")
 	ErrUnknownMessageType = errors.New("unknown message type")
 	ErrInvalidHandler     = errors.New("invalid handler")
 )

--- a/processor/mocks_test.go
+++ b/processor/mocks_test.go
@@ -1,0 +1,27 @@
+package processor
+
+// MockMessage implements the pubsub.MessageAcker interface for testing
+type MockMessage struct {
+	id         string
+	data       []byte
+	attributes map[string]string
+	metadata   map[string]any
+	ackCalled  bool
+	nackCalled bool
+}
+
+func NewMockMessage(id string, data []byte, attributes map[string]string, metadata map[string]any) *MockMessage {
+	return &MockMessage{
+		id:         id,
+		data:       data,
+		attributes: attributes,
+		metadata:   metadata,
+	}
+}
+
+func (m *MockMessage) ID() string                    { return m.id }
+func (m *MockMessage) Data() []byte                  { return m.data }
+func (m *MockMessage) Attributes() map[string]string { return m.attributes }
+func (m *MockMessage) Metadata() map[string]any      { return m.metadata }
+func (m *MockMessage) Ack()                          { m.ackCalled = true }
+func (m *MockMessage) Nack()                         { m.nackCalled = true }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -52,7 +52,7 @@ func New(options ...pubsub.ProcessorOption) *Processor {
 // Register adds a handler for a specific message type
 func (p *Processor) Register(msgType pubsub.MessageType, handler pubsub.MessageHandler) error {
 	if string(msgType) == "" {
-		return ErrInvalidMesageType
+		return ErrInvalidMessageType
 	}
 
 	if handler == nil {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,0 +1,87 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/milosgajdos/pubsub"
+)
+
+// Processor implements MessageProcessor
+type Processor struct {
+	handlers  map[pubsub.MessageType]pubsub.MessageHandler
+	extractor pubsub.MessageTypeExtractor
+	mu        sync.RWMutex
+}
+
+// DefaultExtractor is the default message type extractor
+// By default it will try to extract message type from a JSON message
+// whose type field is "type".
+func DefaultExtractor(data []byte) (pubsub.MessageType, error) {
+	var msg struct {
+		Type string `json:"type"`
+	}
+
+	if err := json.Unmarshal(data, &msg); err == nil && msg.Type != "" {
+		return pubsub.MessageType(msg.Type), nil
+	}
+
+	return "", ErrUnknownMessageType
+}
+
+// New creates a new message processor
+func New(options ...pubsub.ProcessorOption) *Processor {
+	opts := &pubsub.ProcessorOptions{}
+	for _, option := range options {
+		option(opts)
+	}
+
+	extractor := opts.Extractor
+	if extractor == nil {
+		extractor = DefaultExtractor
+	}
+
+	return &Processor{
+		handlers:  make(map[pubsub.MessageType]pubsub.MessageHandler),
+		extractor: extractor,
+	}
+}
+
+// Register adds a handler for a specific message type
+func (p *Processor) Register(msgType pubsub.MessageType, handler pubsub.MessageHandler) error {
+	if string(msgType) == "" {
+		return ErrInvalidMesageType
+	}
+
+	if handler == nil {
+		return ErrInvalidHandler
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.handlers[msgType] = handler
+	return nil
+}
+
+// Process routes a message to its appropriate handler based on type
+func (p *Processor) Process(ctx context.Context, msg pubsub.MessageAcker) error {
+	msgType, err := p.extractor(msg.Data())
+	if err != nil {
+		msg.Nack()
+		return fmt.Errorf("failed to extract message type: %w", err)
+	}
+
+	p.mu.RLock()
+	handler, exists := p.handlers[msgType]
+	p.mu.RUnlock()
+
+	if !exists {
+		msg.Nack()
+		return fmt.Errorf("no handler registered for message type: %s", msgType)
+	}
+
+	return handler(ctx, msg)
+}

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -1,0 +1,218 @@
+package processor
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/milosgajdos/pubsub"
+)
+
+// Simple test extractor that always returns a fixed type
+func testExtractor(_ []byte) (pubsub.MessageType, error) {
+	return pubsub.MessageType("test-type"), nil
+}
+
+// Test extractor that always returns an error
+func errorExtractor(_ []byte) (pubsub.MessageType, error) {
+	return "", errors.New("extraction failed")
+}
+
+func TestNew(t *testing.T) {
+	t.Run("DefaultOptions", func(t *testing.T) {
+		p := New()
+		if p == nil {
+			t.Fatal("New() returned nil")
+		}
+		if p.handlers == nil {
+			t.Error("handlers map was not initialized")
+		}
+		if p.extractor == nil {
+			t.Error("extractor was not set")
+		}
+	})
+
+	t.Run("CustomExtractor", func(t *testing.T) {
+		p := New(pubsub.WithExtractor(testExtractor))
+		if p == nil {
+			t.Fatal("New() with custom extractor returned nil")
+		}
+
+		// Verify the extractor is set correctly
+		msgType, _ := p.extractor([]byte("test"))
+		if msgType != "test-type" {
+			t.Errorf("Custom extractor not set correctly")
+		}
+	})
+}
+
+func TestDefaultExtractor(t *testing.T) {
+	t.Run("ValidData", func(t *testing.T) {
+		mesgType := "test-message-type"
+		data := []byte(`{"type":"` + mesgType + `"}`)
+		extractedType, err := DefaultExtractor(data)
+		if err != nil {
+			t.Errorf("DefaultExtractor returned unexpected error: %v", err)
+		}
+		if extractedType != pubsub.MessageType(mesgType) {
+			t.Errorf("DefaultExtractor returned incorrect type: got %s, want %s", extractedType, mesgType)
+		}
+	})
+
+	t.Run("InvalidJSON", func(t *testing.T) {
+		data := []byte(`{invalid json`)
+		msgType, err := DefaultExtractor(data)
+		if err != ErrUnknownMessageType {
+			t.Errorf("Expected ErrUnknownMessageType, got: %v", err)
+		}
+		if msgType != "" {
+			t.Errorf("Expected empty message type, got: %s", msgType)
+		}
+	})
+
+	t.Run("MissingTypeField", func(t *testing.T) {
+		data := []byte(`{"message":"no type field"}`)
+		msgType, err := DefaultExtractor(data)
+		if err != ErrUnknownMessageType {
+			t.Errorf("Expected ErrUnknownMessageType, got: %v", err)
+		}
+		if msgType != "" {
+			t.Errorf("Expected empty message type, got: %s", msgType)
+		}
+	})
+}
+
+func TestRegister(t *testing.T) {
+	t.Run("ValidRegistration", func(t *testing.T) {
+		p := New()
+		msgType := pubsub.MessageType("test-type")
+		handler := func(context.Context, pubsub.MessageAcker) error {
+			return nil
+		}
+
+		err := p.Register(msgType, handler)
+		if err != nil {
+			t.Errorf("Register returned unexpected error: %v", err)
+		}
+
+		p.mu.RLock()
+		registeredHandler, exists := p.handlers[msgType]
+		p.mu.RUnlock()
+
+		if !exists {
+			t.Error("Handler was not registered")
+		}
+		// gotta make sure we get the same handler back
+		if reflect.ValueOf(registeredHandler).Pointer() != reflect.ValueOf(handler).Pointer() {
+			t.Error("Registered handler does not match the provided handler")
+		}
+	})
+
+	t.Run("EmptyMessageType", func(t *testing.T) {
+		p := New()
+		err := p.Register("", func(context.Context, pubsub.MessageAcker) error {
+			return nil
+		})
+
+		if err != ErrInvalidMessageType {
+			t.Errorf("Expected ErrInvalidMessageType, got: %v", err)
+		}
+	})
+
+	t.Run("NilHandler", func(t *testing.T) {
+		p := New()
+		err := p.Register("test-type", nil)
+
+		if err != ErrInvalidHandler {
+			t.Errorf("Expected ErrInvalidHandler, got: %v", err)
+		}
+	})
+}
+
+func TestProcess(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("SuccessfulProcessing", func(t *testing.T) {
+		p := New(pubsub.WithExtractor(testExtractor))
+
+		// Prepare test data
+		msgData := []byte("test message data")
+		msg := NewMockMessage("test-id", msgData, nil, nil)
+		handlerCalled := false
+
+		err := p.Register("test-type", func(context.Context, pubsub.MessageAcker) error {
+			handlerCalled = true
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("Failed to register handler: %v", err)
+		}
+
+		err = p.Process(ctx, msg)
+		if err != nil {
+			t.Errorf("Process returned unexpected error: %v", err)
+		}
+
+		// Verify handler was called
+		if !handlerCalled {
+			t.Error("Handler was not called")
+		}
+	})
+
+	t.Run("ExtractorError", func(t *testing.T) {
+		p := New(pubsub.WithExtractor(errorExtractor))
+
+		msg := NewMockMessage("test-id", []byte("test data"), nil, nil)
+
+		err := p.Process(ctx, msg)
+		if err == nil {
+			t.Error("Process should have returned an error")
+		}
+
+		// Verify message was nacked
+		if !msg.nackCalled {
+			t.Error("Message should have been nacked")
+		}
+	})
+
+	t.Run("NoHandlerForType", func(t *testing.T) {
+		p := New(pubsub.WithExtractor(testExtractor))
+
+		msg := NewMockMessage("test-id", []byte("test data"), nil, nil)
+
+		// No handler registered, so Process should return an error
+		err := p.Process(ctx, msg)
+		if err == nil {
+			t.Error("Process should have returned an error")
+		}
+
+		// Verify message was nacked
+		if !msg.nackCalled {
+			t.Error("Message should have been nacked")
+		}
+	})
+
+	t.Run("HandlerError", func(t *testing.T) {
+		p := New(pubsub.WithExtractor(testExtractor))
+
+		// Prepare test data
+		msgData := []byte("test message data")
+		msg := NewMockMessage("test-id", msgData, nil, nil)
+		expectedErr := errors.New("handler error")
+
+		// Register handler that returns an error
+		err := p.Register("test-type", func(context.Context, pubsub.MessageAcker) error {
+			return expectedErr
+		})
+		if err != nil {
+			t.Fatalf("Failed to register handler: %v", err)
+		}
+
+		// Process message
+		err = p.Process(ctx, msg)
+		if err != expectedErr {
+			t.Errorf("Process returned wrong error: got %v, want %v", err, expectedErr)
+		}
+	})
+}

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -39,7 +39,6 @@ func TestNew(t *testing.T) {
 			t.Fatal("New() with custom extractor returned nil")
 		}
 
-		// Verify the extractor is set correctly
 		msgType, _ := p.extractor([]byte("test"))
 		if msgType != "test-type" {
 			t.Errorf("Custom extractor not set correctly")
@@ -49,22 +48,22 @@ func TestNew(t *testing.T) {
 
 func TestDefaultExtractor(t *testing.T) {
 	t.Run("ValidData", func(t *testing.T) {
-		mesgType := "test-message-type"
-		data := []byte(`{"type":"` + mesgType + `"}`)
+		msgType := "test-message-type"
+		data := []byte(`{"type":"` + msgType + `"}`)
 		extractedType, err := DefaultExtractor(data)
 		if err != nil {
 			t.Errorf("DefaultExtractor returned unexpected error: %v", err)
 		}
-		if extractedType != pubsub.MessageType(mesgType) {
-			t.Errorf("DefaultExtractor returned incorrect type: got %s, want %s", extractedType, mesgType)
+		if extractedType != pubsub.MessageType(msgType) {
+			t.Errorf("DefaultExtractor returned incorrect type: got %s, want %s", extractedType, msgType)
 		}
 	})
 
 	t.Run("InvalidJSON", func(t *testing.T) {
 		data := []byte(`{invalid json`)
 		msgType, err := DefaultExtractor(data)
-		if err != ErrUnknownMessageType {
-			t.Errorf("Expected ErrUnknownMessageType, got: %v", err)
+		if !errors.Is(err, ErrUnknownMessageType) {
+			t.Errorf("Expected %v, got: %v", ErrUnknownMessageType, err)
 		}
 		if msgType != "" {
 			t.Errorf("Expected empty message type, got: %s", msgType)
@@ -74,8 +73,8 @@ func TestDefaultExtractor(t *testing.T) {
 	t.Run("MissingTypeField", func(t *testing.T) {
 		data := []byte(`{"message":"no type field"}`)
 		msgType, err := DefaultExtractor(data)
-		if err != ErrUnknownMessageType {
-			t.Errorf("Expected ErrUnknownMessageType, got: %v", err)
+		if !errors.Is(err, ErrUnknownMessageType) {
+			t.Errorf("Expected %v, got: %v", ErrUnknownMessageType, err)
 		}
 		if msgType != "" {
 			t.Errorf("Expected empty message type, got: %s", msgType)
@@ -123,9 +122,8 @@ func TestRegister(t *testing.T) {
 	t.Run("NilHandler", func(t *testing.T) {
 		p := New()
 		err := p.Register("test-type", nil)
-
-		if err != ErrInvalidHandler {
-			t.Errorf("Expected ErrInvalidHandler, got: %v", err)
+		if !errors.Is(err, ErrInvalidHandler) {
+			t.Errorf("Expected %v, got: %v", ErrInvalidHandler, err)
 		}
 	})
 }
@@ -211,7 +209,7 @@ func TestProcess(t *testing.T) {
 
 		// Process message
 		err = p.Process(ctx, msg)
-		if err != expectedErr {
+		if !errors.Is(err, expectedErr) {
 			t.Errorf("Process returned wrong error: got %v, want %v", err, expectedErr)
 		}
 	})

--- a/processor/register.go
+++ b/processor/register.go
@@ -1,0 +1,36 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/milosgajdos/pubsub"
+)
+
+// Handler is a type-safe handler for a specific message type.
+type Handler[T any] func(ctx context.Context, data T) error
+
+// RegisterTyped registers a type-safe handler for a specific message type
+func Register[T any](p pubsub.MessageProcessor, msgType pubsub.MessageType, handler Handler[T]) error {
+	// Create a wrapper handler that:
+	// 1. Unmarshals the message data into type T
+	// 2. Calls the handler with the typed data
+	wrappedHandler := func(ctx context.Context, msg pubsub.MessageAcker) error {
+		var data T
+		if err := json.Unmarshal(msg.Data(), &data); err != nil {
+			msg.Nack()
+			return fmt.Errorf("failed to unmarshal message: %w", err)
+		}
+
+		if err := handler(ctx, data); err != nil {
+			msg.Nack()
+			return err
+		}
+
+		msg.Ack()
+		return nil
+	}
+
+	return p.Register(msgType, wrappedHandler)
+}

--- a/processor/register.go
+++ b/processor/register.go
@@ -11,7 +11,7 @@ import (
 // Handler is a type-safe handler for a specific message type.
 type Handler[T any] func(ctx context.Context, data T) error
 
-// RegisterTyped registers a type-safe handler for a specific message type
+// Register registers a type-safe handler for a specific message type
 func Register[T any](p pubsub.MessageProcessor, msgType pubsub.MessageType, handler Handler[T]) error {
 	// Create a wrapper handler that:
 	// 1. Unmarshals the message data into type T

--- a/processor/register_test.go
+++ b/processor/register_test.go
@@ -1,0 +1,255 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/milosgajdos/pubsub"
+)
+
+// TestEvent is a simple event structure used for testing
+type TestEvent struct {
+	ID      string `json:"id"`
+	Message string `json:"message"`
+}
+
+// ComplexTestEvent is a more complex event for testing
+type ComplexTestEvent struct {
+	UserID    string   `json:"user_id"`
+	Email     string   `json:"email"`
+	Items     []string `json:"items"`
+	Processed bool     `json:"processed"`
+}
+
+func TestRegisterTyped(t *testing.T) {
+	t.Run("SuccessfulHandling", func(t *testing.T) {
+		p := New()
+
+		// Test data
+		expectedID := "test-123"
+		expectedMessage := "hello world"
+
+		// Track if handler is called
+		handlerCalled := false
+		var capturedEvent TestEvent
+
+		// Register typed handler
+		err := Register(p, "test-event",
+			func(_ context.Context, event TestEvent) error {
+				handlerCalled = true
+				capturedEvent = event
+				return nil
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Failed to register handler: %v", err)
+		}
+
+		// Create test message
+		testEvent := TestEvent{
+			ID:      expectedID,
+			Message: expectedMessage,
+		}
+
+		eventData, _ := json.Marshal(testEvent)
+
+		// Create a mock message
+		mockMessage := &MockMessage{
+			id:   "msg-1",
+			data: eventData,
+		}
+
+		// Mock the extractor
+		p.extractor = func(_ []byte) (pubsub.MessageType, error) {
+			return "test-event", nil
+		}
+
+		err = p.Process(context.Background(), mockMessage)
+		if err != nil {
+			t.Errorf("Process returned error: %v", err)
+		}
+
+		// Verify handler was called with correct data
+		if !handlerCalled {
+			t.Error("Handler was not called")
+		}
+
+		if capturedEvent.ID != expectedID {
+			t.Errorf("Wrong ID: got %s, want %s", capturedEvent.ID, expectedID)
+		}
+
+		if capturedEvent.Message != expectedMessage {
+			t.Errorf("Wrong message: got %s, want %s", capturedEvent.Message, expectedMessage)
+		}
+
+		// Verify message was acked
+		if !mockMessage.ackCalled {
+			t.Error("Message was not acked")
+		}
+	})
+
+	t.Run("ComplexEventHandling", func(t *testing.T) {
+		p := New()
+
+		// Test data
+		complexEvent := ComplexTestEvent{
+			UserID:    "user-123",
+			Email:     "test@example.com",
+			Items:     []string{"item1", "item2", "item3"},
+			Processed: true,
+		}
+		complexEventType := pubsub.MessageType("complex-event")
+
+		// Track if handler is called
+		handlerCalled := false
+		var capturedEvent ComplexTestEvent
+
+		// Register typed handler
+		err := Register(p, complexEventType,
+			func(_ context.Context, event ComplexTestEvent) error {
+				handlerCalled = true
+				capturedEvent = event
+				return nil
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Failed to register handler: %v", err)
+		}
+
+		// Create message data
+		eventData, err := json.Marshal(complexEvent)
+		if err != nil {
+			t.Fatalf("Failed to Marhsal event data: %v", err)
+		}
+
+		// Create a mock message
+		mockMessage := &MockMessage{
+			id:   "complex-msg-1",
+			data: eventData,
+		}
+
+		// Mock the extractor
+		p.extractor = func(_ []byte) (pubsub.MessageType, error) {
+			return complexEventType, nil
+		}
+
+		// Process the message
+		err = p.Process(context.Background(), mockMessage)
+		if err != nil {
+			t.Errorf("Process returned error: %v", err)
+		}
+
+		// Verify handler was called with correct data
+		if !handlerCalled {
+			t.Error("Handler was not called")
+		}
+
+		if capturedEvent.UserID != complexEvent.UserID {
+			t.Errorf("Wrong UserID: got %s, want %s", capturedEvent.UserID, complexEvent.UserID)
+		}
+
+		if capturedEvent.Email != complexEvent.Email {
+			t.Errorf("Wrong Email: got %s, want %s", capturedEvent.Email, complexEvent.Email)
+		}
+
+		if len(capturedEvent.Items) != len(complexEvent.Items) {
+			t.Errorf("Wrong number of items: got %d, want %d", len(capturedEvent.Items), len(complexEvent.Items))
+		}
+
+		// Verify message was acked
+		if !mockMessage.ackCalled {
+			t.Error("Message was not acked")
+		}
+	})
+
+	t.Run("UnmarshalError", func(t *testing.T) {
+		p := New()
+
+		// Register typed handler
+		testEventType := pubsub.MessageType("test-event")
+		err := Register(p, testEventType,
+			func(context.Context, TestEvent) error {
+				// This should not be called
+				t.Error("Handler should not be called for invalid data")
+				return nil
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Failed to register handler: %v", err)
+		}
+
+		// Invalid JSON data
+		invalidData := []byte(`{invalid json`)
+
+		mockMessage := &MockMessage{
+			id:   "msg-1",
+			data: invalidData,
+		}
+
+		// Mock the extractor
+		p.extractor = func(_ []byte) (pubsub.MessageType, error) {
+			return testEventType, nil
+		}
+
+		err = p.Process(context.Background(), mockMessage)
+		if err == nil {
+			t.Error("Process should have returned an error for invalid JSON")
+		}
+
+		// Verify message was nacked
+		if !mockMessage.nackCalled {
+			t.Error("Message was not nacked")
+		}
+	})
+
+	t.Run("HandlerError", func(t *testing.T) {
+		p := New()
+
+		expectedErr := errors.New("handler error")
+		testEventType := pubsub.MessageType("test-event")
+
+		// Register typed handler that returns an error
+		err := Register(p, testEventType,
+			func(context.Context, TestEvent) error {
+				return expectedErr
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Failed to register handler: %v", err)
+		}
+
+		// Create test event
+		testEvent := TestEvent{
+			ID:      "test-123",
+			Message: "hello world",
+		}
+
+		eventData, _ := json.Marshal(testEvent)
+
+		mockMessage := &MockMessage{
+			id:   "msg-1",
+			data: eventData,
+		}
+
+		// Mock the extractor
+		p.extractor = func(_ []byte) (pubsub.MessageType, error) {
+			return testEventType, nil
+		}
+
+		err = p.Process(context.Background(), mockMessage)
+		if err != expectedErr {
+			t.Errorf("Process returned wrong error: got %v, want %v", err, expectedErr)
+		}
+
+		// Verify message was nacked
+		if !mockMessage.nackCalled {
+			t.Error("Message was not nacked")
+		}
+	})
+}

--- a/processor/register_test.go
+++ b/processor/register_test.go
@@ -123,7 +123,7 @@ func TestRegisterTyped(t *testing.T) {
 		// Create message data
 		eventData, err := json.Marshal(complexEvent)
 		if err != nil {
-			t.Fatalf("Failed to Marhsal event data: %v", err)
+			t.Fatalf("Failed to Marshal event data: %v", err)
 		}
 
 		// Create a mock message

--- a/pubsub.go
+++ b/pubsub.go
@@ -6,9 +6,13 @@ import (
 
 // Message represents a message in the PubSub system
 type Message interface {
+	// ID returns the unique identifier of the message
 	ID() string
+	// Data returns the payload of the message
 	Data() []byte
+	// Metadata returns the metadata of the message
 	Metadata() map[string]any
+	// Attributes returns the attributes of the message
 	Attributes() map[string]string
 }
 
@@ -16,21 +20,43 @@ type Message interface {
 // that can be acked or nacked
 type MessageAcker interface {
 	Message
+	// Ack acknowledges the message
 	Ack()
+	// Nack nacks the message
 	Nack()
 }
 
 // Publisher is responsible for publishing messages
 type Publisher interface {
+	// Publish publishes a message to the PubSub system
 	Publish(ctx context.Context, message Message) (string, error)
+	// PublishBatch publishes a batch of messages to the PubSub system
 	PublishBatch(ctx context.Context, messages []Message) ([]string, error)
 }
 
-// MessageHandler processes incoming messages
+// MessageHandler processes incoming messages from the PubSub system.
 // The handler is responsible for acking or nacking messages
 type MessageHandler func(ctx context.Context, msg MessageAcker) error
 
 // Subscriber is responsible for consuming messages
 type Subscriber interface {
+	// Subscribe registers a handler for incoming messages
 	Subscribe(ctx context.Context, handler MessageHandler) error
+}
+
+// MessageType is the type of the message that needs to be processed
+type MessageType string
+
+// MessageUnmarshaler defines how to unmarshal a message's data
+type MessageUnmarshaler interface {
+	// Unmarshal converts raw message data into a specific type
+	Unmarshal(data []byte, v any) error
+}
+
+// MessageProcessor handles message routing to appropriate handlers
+type MessageProcessor interface {
+	// Register adds a handler for a specific message type
+	Register(msgType MessageType, handler MessageHandler) error
+	// Process routes a message to its appropriate handler based on type
+	Process(ctx context.Context, msg Message) error
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -26,6 +26,30 @@ type MessageAcker interface {
 	Nack()
 }
 
+// MessageHandler processes incoming messages from the PubSub system.
+// The handler is responsible for acking or nacking messages
+type MessageHandler func(ctx context.Context, msg MessageAcker) error
+
+// MessageUnmarshaler defines how to unmarshal a message's data
+type MessageUnmarshaler interface {
+	// Unmarshal converts raw message data into a specific type
+	Unmarshal(data []byte, v any) error
+}
+
+// MessageType is the type of the message that needs to be processed
+type MessageType string
+
+// MessageTypeExtractor extracts message type from data and returns it
+type MessageTypeExtractor func(data []byte) (MessageType, error)
+
+// MessageProcessor handles message routing to appropriate handlers
+type MessageProcessor interface {
+	// Register adds a handler for a specific message type
+	Register(msgType MessageType, handler MessageHandler) error
+	// Process routes a message to appropriate handler based on type
+	Process(ctx context.Context, msg MessageAcker) error
+}
+
 // Publisher is responsible for publishing messages
 type Publisher interface {
 	// Publish publishes a message to the PubSub system
@@ -34,29 +58,8 @@ type Publisher interface {
 	PublishBatch(ctx context.Context, messages []Message) ([]string, error)
 }
 
-// MessageHandler processes incoming messages from the PubSub system.
-// The handler is responsible for acking or nacking messages
-type MessageHandler func(ctx context.Context, msg MessageAcker) error
-
 // Subscriber is responsible for consuming messages
 type Subscriber interface {
 	// Subscribe registers a handler for incoming messages
 	Subscribe(ctx context.Context, handler MessageHandler) error
-}
-
-// MessageType is the type of the message that needs to be processed
-type MessageType string
-
-// MessageUnmarshaler defines how to unmarshal a message's data
-type MessageUnmarshaler interface {
-	// Unmarshal converts raw message data into a specific type
-	Unmarshal(data []byte, v any) error
-}
-
-// MessageProcessor handles message routing to appropriate handlers
-type MessageProcessor interface {
-	// Register adds a handler for a specific message type
-	Register(msgType MessageType, handler MessageHandler) error
-	// Process routes a message to its appropriate handler based on type
-	Process(ctx context.Context, msg Message) error
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add a message processor for handling Pub/Sub messages with type-safe handler registration and improved error handling.
> 
>   - **Processor Implementation**:
>     - Adds `Processor` in `processor/processor.go` to handle message routing using registered handlers.
>     - Implements `DefaultExtractor` for extracting message types from JSON data.
>     - Adds `Register` function in `processor/register.go` for type-safe handler registration.
>   - **Error Handling**:
>     - Defines errors like `ErrInvalidMessageType`, `ErrUnknownMessageType`, and `ErrInvalidHandler` in `processor/errors.go`.
>   - **Testing**:
>     - Adds unit tests for `Processor` and `Register` in `processor/processor_test.go` and `processor/register_test.go`.
>     - Introduces `MockMessage` in `processor/mocks_test.go` for testing purposes.
>   - **Refactoring**:
>     - Refactors imports in `gcp/message.go`, `gcp/publisher.go`, and `gcp/subscriber.go` to use alias `gps` for `cloud.google.com/go/pubsub`.
>     - Updates `NewMessage` function in `gcp/message.go` to initialize metadata if nil.
>   - **Options and Interfaces**:
>     - Adds `ProcessorOptions` and related functions in `options.go` for configuring processors.
>     - Updates `pubsub.go` to include new interfaces like `MessageProcessor` and `MessageTypeExtractor`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=milosgajdos%2Fpubsub&utm_source=github&utm_medium=referral)<sup> for e556e2a68e39b0dda4736160b7cc8cca52645f49. You can [customize](https://app.ellipsis.dev/milosgajdos/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->