### PR TITLE
Add otel tracing

### DIFF
--- a/gcp/publisher.go
+++ b/gcp/publisher.go
@@ -74,9 +74,9 @@ func (p *Publisher) Publish(ctx context.Context, message pubsub.Message) (string
 	// Create message attributes
 	attributes := message.Attributes()
 
+	var span trace.Span
 	// Add tracing context to attributes if tracing is enabled
 	if p.tracingEnabled {
-		var span trace.Span
 		ctx, span = tracing.StartPublishSpan(ctx, p.topic.ID())
 		defer span.End()
 
@@ -94,7 +94,6 @@ func (p *Publisher) Publish(ctx context.Context, message pubsub.Message) (string
 
 	// Record any errors in the span if tracing is enabled
 	if err != nil && p.tracingEnabled {
-		span := trace.SpanFromContext(ctx)
 		span.RecordError(err)
 	}
 
@@ -104,8 +103,8 @@ func (p *Publisher) Publish(ctx context.Context, message pubsub.Message) (string
 // PublishBatch publishes a batch of messages to the topic
 func (p *Publisher) PublishBatch(ctx context.Context, messages []pubsub.Message) ([]string, error) {
 	// Start a batch publish span if tracing is enabled
+	var span trace.Span
 	if p.tracingEnabled {
-		var span trace.Span
 		ctx, span = tracing.StartPublishSpan(ctx, p.topic.ID()+"-batch")
 		defer span.End()
 	}
@@ -125,7 +124,6 @@ func (p *Publisher) PublishBatch(ctx context.Context, messages []pubsub.Message)
 	if lastErr != nil && len(ids) < len(messages) {
 		// Record error in span if tracing is enabled
 		if p.tracingEnabled {
-			span := trace.SpanFromContext(ctx)
 			span.RecordError(lastErr)
 		}
 		return ids, fmt.Errorf("failed to publish some messages: %w", lastErr)

--- a/gcp/publisher.go
+++ b/gcp/publisher.go
@@ -11,6 +11,7 @@ import (
 	gps "cloud.google.com/go/pubsub"
 	vkit "cloud.google.com/go/pubsub/apiv1"
 	gax "github.com/googleapis/gax-go/v2"
+	otel "go.opentelemetry.io/otel/codes"
 
 	"github.com/milosgajdos/pubsub"
 	"github.com/milosgajdos/pubsub/tracing"
@@ -95,6 +96,7 @@ func (p *Publisher) Publish(ctx context.Context, message pubsub.Message) (string
 	// Record any errors in the span if tracing is enabled
 	if err != nil && p.tracingEnabled {
 		span.RecordError(err)
+		span.SetStatus(otel.Error, err.Error())
 	}
 
 	return id, err
@@ -125,6 +127,7 @@ func (p *Publisher) PublishBatch(ctx context.Context, messages []pubsub.Message)
 		// Record error in span if tracing is enabled
 		if p.tracingEnabled {
 			span.RecordError(lastErr)
+			span.SetStatus(otel.Error, lastErr.Error())
 		}
 		return ids, fmt.Errorf("failed to publish some messages: %w", lastErr)
 	}

--- a/gcp/publisher.go
+++ b/gcp/publisher.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 
 	gps "cloud.google.com/go/pubsub"
@@ -12,15 +13,17 @@ import (
 	gax "github.com/googleapis/gax-go/v2"
 
 	"github.com/milosgajdos/pubsub"
+	"github.com/milosgajdos/pubsub/tracing"
 )
 
 // Publisher implements the pubsub.Publisher interface for Google Cloud Pub/Sub
 // TODO: client and topic should be interfaces so we can write unit tests.
 type Publisher struct {
-	projectID string
-	client    *gps.Client
-	topic     *gps.Topic
-	settings  *gps.PublishSettings
+	projectID      string
+	client         *gps.Client
+	topic          *gps.Topic
+	settings       *gps.PublishSettings
+	tracingEnabled bool
 }
 
 // NewPublisher creates a new Google Cloud Pub/Sub publisher
@@ -58,26 +61,55 @@ func NewPublisher(ctx context.Context, projectID string, options ...pubsub.PubOp
 	topic.PublishSettings = *publishSettings
 
 	return &Publisher{
-		projectID: projectID,
-		client:    client,
-		topic:     topic,
-		settings:  publishSettings,
+		projectID:      projectID,
+		client:         client,
+		topic:          topic,
+		settings:       publishSettings,
+		tracingEnabled: opts.TracingEnabled,
 	}, nil
 }
 
 // Publish publishes a message to the topic
 func (p *Publisher) Publish(ctx context.Context, message pubsub.Message) (string, error) {
+	// Create message attributes
+	attributes := message.Attributes()
+
+	// Add tracing context to attributes if tracing is enabled
+	if p.tracingEnabled {
+		var span trace.Span
+		ctx, span = tracing.StartPublishSpan(ctx, p.topic.ID())
+		defer span.End()
+
+		// Inject tracing context into message attributes
+		attributes = tracing.InjectTracingContext(ctx, attributes)
+	}
+
 	result := p.topic.Publish(ctx, &gps.Message{
 		Data:       message.Data(),
-		Attributes: message.Attributes(),
+		Attributes: attributes,
 	})
 
 	// Block until the result is returned and ID is assigned
-	return result.Get(ctx)
+	id, err := result.Get(ctx)
+
+	// Record any errors in the span if tracing is enabled
+	if err != nil && p.tracingEnabled {
+		span := trace.SpanFromContext(ctx)
+		span.RecordError(err)
+	}
+
+	return id, err
 }
 
 // PublishBatch publishes a batch of messages to the topic
 func (p *Publisher) PublishBatch(ctx context.Context, messages []pubsub.Message) ([]string, error) {
+	// Start a batch publish span if tracing is enabled
+	if p.tracingEnabled {
+		var span trace.Span
+		ctx, span = tracing.StartPublishSpan(ctx, p.topic.ID()+"-batch")
+		defer span.End()
+	}
+
 	ids := make([]string, 0, len(messages))
 	var lastErr error
 
@@ -91,6 +123,11 @@ func (p *Publisher) PublishBatch(ctx context.Context, messages []pubsub.Message)
 	}
 
 	if lastErr != nil && len(ids) < len(messages) {
+		// Record error in span if tracing is enabled
+		if p.tracingEnabled {
+			span := trace.SpanFromContext(ctx)
+			span.RecordError(lastErr)
+		}
 		return ids, fmt.Errorf("failed to publish some messages: %w", lastErr)
 	}
 

--- a/gcp/subscriber.go
+++ b/gcp/subscriber.go
@@ -118,11 +118,11 @@ func (s *Subscriber) Subscribe(ctx context.Context, handler pubsub.MessageHandle
 		// Create a message that implements the MessageAcker interface
 		message := NewMessage(msg, pubsub.WithMetadata(metadata))
 
+		var span trace.Span
 		// Extract tracing context from message attributes if tracing is enabled
 		if s.tracingEnabled {
 			ctx = tracing.ExtractTracingContext(ctx, msg.Attributes)
 			// Start a new span for message processing
-			var span trace.Span
 			ctx, span = tracing.StartMessageProcessingSpan(ctx, message.ID(), s.topicID, s.subscriptionID, messageType)
 			defer span.End()
 		}
@@ -137,7 +137,6 @@ func (s *Subscriber) Subscribe(ctx context.Context, handler pubsub.MessageHandle
 
 			// Record error in span if tracing is enabled
 			if s.tracingEnabled {
-				span := trace.SpanFromContext(ctx)
 				span.RecordError(err)
 				span.SetStatus(otel.Error, err.Error())
 			}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,11 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.14.1
 	github.com/testcontainers/testcontainers-go v0.37.0
+	go.opentelemetry.io/otel v1.35.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0
+	go.opentelemetry.io/otel/sdk v1.35.0
+	go.opentelemetry.io/otel/trace v1.35.0
 	google.golang.org/api v0.232.0
 	google.golang.org/grpc v1.72.0
 )
@@ -39,6 +44,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
@@ -65,10 +71,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
-	go.opentelemetry.io/otel v1.35.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
-	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
 	golang.org/x/net v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
+github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -179,6 +181,8 @@ go.opentelemetry.io/otel v1.35.0 h1:xKWKPxrxB6OtMCbmMY021CqC45J+3Onta9MqjhnusiQ=
 go.opentelemetry.io/otel v1.35.0/go.mod h1:UEqy8Zp11hpkUrL73gSlELM0DupHoiq72dR+Zqel/+Y=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 h1:Mne5On7VWdx7omSrSSZvM4Kw7cS7NQkOOmLcgscI51U=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0/go.mod h1:IPtUMKL4O3tH5y+iXVyAXqpAwMuzC1IrxVS81rummfE=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0 h1:3d+S281UTjM+AbF31XSOYn1qXn3BgIdWl8HNEpx08Jk=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0/go.mod h1:0+KuTDyKL4gjKCF75pHOX4wuzYDUZYfAQdSu43o+Z2I=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0 h1:IeMeyr1aBvBiPVYihXIaeIZba6b8E1bYp7lbdxK8CQg=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0/go.mod h1:oVdCUtjq9MK9BlS7TtucsQwUcXcymNiEDjgDD2jMtZU=
 go.opentelemetry.io/otel/metric v1.35.0 h1:0znxYu2SNyuMSQT4Y9WDWej0VpcsxkuklLa4/siN90M=
@@ -191,6 +195,8 @@ go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/options.go
+++ b/options.go
@@ -8,6 +8,8 @@ type PubOptions struct {
 	Batch *Batch
 	// Retry configures retry settings
 	Retry *Retry
+	// TracingEnabled enables OpenTelemetry tracing
+	TracingEnabled bool
 }
 
 // PubOption is used for configuring publishers
@@ -40,6 +42,13 @@ func WithPubRetry(retry Retry) PubOption {
 	}
 }
 
+// WithPubTracing enables OpenTelemetry tracing for publishers
+func WithPubTracing() PubOption {
+	return func(o *PubOptions) {
+		o.TracingEnabled = true
+	}
+}
+
 // Retry is used for retry settings
 type Retry struct {
 	// InitBackoffSeconds is initial backoff in seconds
@@ -56,6 +65,8 @@ type SubOptions struct {
 	Retry *Retry
 	// Concurrency configures concurrency settings
 	Concurrency int
+	// TracingEnabled enables OpenTelemetry tracing
+	TracingEnabled bool
 }
 
 // SubOption is used for configuring subscribers
@@ -79,6 +90,13 @@ func WithSubRetry(retry Retry) SubOption {
 func WithConcurrency(concurrency int) SubOption {
 	return func(o *SubOptions) {
 		o.Concurrency = concurrency
+	}
+}
+
+// WithSubTracing enables OpenTelemetry tracing for subscribers
+func WithSubTracing() SubOption {
+	return func(o *SubOptions) {
+		o.TracingEnabled = true
 	}
 }
 

--- a/tracing/otel.go
+++ b/tracing/otel.go
@@ -1,0 +1,165 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// PubSubTracerName is the name of the tracer for the PubSub system
+	PubSubTracerName = "github.com/milosgajdos/pubsub"
+)
+
+// GlobalTracer provides access to the global tracer
+var GlobalTracer trace.Tracer
+
+// TraceConfig holds configuration for OpenTelemetry tracing
+type TraceConfig struct {
+	// Enabled indicates if tracing is enabled
+	Enabled bool
+	// ServiceName is the name of the service
+	ServiceName string
+	// ServiceVersion is the version of the service
+	ServiceVersion string
+	// Environment is the environment (e.g., "development", "production")
+	Environment string
+	// OTLPEndpoint is the endpoint for the OTLP exporter (e.g., "localhost:4317")
+	OTLPEndpoint string
+	// SampleRate is the fraction of traces to sample (0.0 to 1.0)
+	SampleRate float64
+}
+
+// InitTracing initializes OpenTelemetry tracing
+func InitTracing(ctx context.Context, config TraceConfig) (func(context.Context) error, error) {
+	if !config.Enabled {
+		// Return no-op cleanup function if tracing is disabled
+		return func(context.Context) error { return nil }, nil
+	}
+
+	if config.ServiceName == "" {
+		config.ServiceName = "pubsub-service"
+	}
+
+	if config.OTLPEndpoint == "" {
+		config.OTLPEndpoint = "localhost:4317"
+	}
+
+	if config.SampleRate <= 0 {
+		config.SampleRate = 1.0 // Default to 100% sampling
+	}
+
+	// Create resource with service information
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(config.ServiceName),
+			semconv.ServiceVersion(config.ServiceVersion),
+			attribute.String("environment", config.Environment),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource: %w", err)
+	}
+
+	// Create OTLP exporter
+	client := otlptracegrpc.NewClient(
+		otlptracegrpc.WithEndpoint(config.OTLPEndpoint),
+		otlptracegrpc.WithInsecure(),
+	)
+	exporter, err := otlptrace.New(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
+	}
+
+	// Create trace provider with the exporter
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.TraceIDRatioBased(config.SampleRate)),
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+
+	// Set global trace provider
+	otel.SetTracerProvider(tp)
+
+	// Setup context propagation
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	// Get global tracer
+	GlobalTracer = otel.Tracer(PubSubTracerName)
+
+	// Return cleanup function
+	return func(ctx context.Context) error {
+		// Shutdown trace provider with timeout
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		return tp.Shutdown(ctxWithTimeout)
+	}, nil
+}
+
+// StartMessageProcessingSpan starts a new span for message processing
+func StartMessageProcessingSpan(ctx context.Context, msgID, topic, subscription, msgType string) (context.Context, trace.Span) {
+	if GlobalTracer == nil {
+		// If tracing is not initialized, use noop tracer
+		return ctx, trace.SpanFromContext(ctx)
+	}
+
+	// Try to extract existing context from attributes if available
+	ctx, span := GlobalTracer.Start(ctx, "process_message",
+		trace.WithAttributes(
+			attribute.String("messaging.system", "pubsub"),
+			attribute.String("messaging.destination", topic),
+			attribute.String("messaging.destination_kind", "topic"),
+			attribute.String("messaging.pubsub.subscription", subscription),
+			attribute.String("messaging.message_id", msgID),
+			attribute.String("messaging.message_type", msgType),
+		),
+	)
+
+	return ctx, span
+}
+
+// StartPublishSpan starts a new span for publishing a message
+func StartPublishSpan(ctx context.Context, topic string) (context.Context, trace.Span) {
+	if GlobalTracer == nil {
+		// If tracing is not initialized, use noop tracer
+		return ctx, trace.SpanFromContext(ctx)
+	}
+
+	ctx, span := GlobalTracer.Start(ctx, "publish_message",
+		trace.WithAttributes(
+			attribute.String("messaging.system", "pubsub"),
+			attribute.String("messaging.destination", topic),
+			attribute.String("messaging.destination_kind", "topic"),
+		),
+	)
+
+	return ctx, span
+}
+
+// InjectTracingContext injects tracing context into attributes map
+func InjectTracingContext(ctx context.Context, attributes map[string]string) map[string]string {
+	if attributes == nil {
+		attributes = make(map[string]string)
+	}
+
+	otel.GetTextMapPropagator().Inject(ctx, propagation.MapCarrier(attributes))
+	return attributes
+}
+
+// ExtractTracingContext extracts tracing context from attributes map
+func ExtractTracingContext(ctx context.Context, attributes map[string]string) context.Context {
+	return otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier(attributes))
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds OpenTelemetry tracing to Google Cloud Pub/Sub publisher and subscriber for enhanced observability.
> 
>   - **Tracing Integration**:
>     - Adds OpenTelemetry tracing to `Publisher` and `Subscriber` in `publisher.go` and `subscriber.go`.
>     - Introduces `tracingEnabled` flag in `Publisher` and `Subscriber` structs.
>     - Implements `StartPublishSpan` and `StartMessageProcessingSpan` in `tracing/otel.go` for span creation.
>     - Injects and extracts tracing context in message attributes.
>   - **Options**:
>     - Adds `TracingEnabled` to `PubOptions` and `SubOptions` in `options.go`.
>     - Adds `WithPubTracing` and `WithSubTracing` functions for enabling tracing.
>   - **Dependencies**:
>     - Updates `go.mod` and `go.sum` to include OpenTelemetry packages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=milosgajdos%2Fpubsub&utm_source=github&utm_medium=referral)<sup> for 771279586856fa964ad3eec474ad44a6f5ebb4a2. You can [customize](https://app.ellipsis.dev/milosgajdos/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->